### PR TITLE
make browsershot getter public for more flexibility

### DIFF
--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -124,7 +124,7 @@ abstract class Wrapper
      */
     protected function generateTempFile(): self
     {
-        $fileName = 'BrowsershotOutput' . time() . Str::random(5) . '.' . $this->getFileExtension();
+        $fileName = 'BrowsershotOutput'.time().Str::random(5).'.'.$this->getFileExtension();
         $tempFileName = (new TemporaryDirectory($this->tempDir))
             ->create()
             ->path($fileName);
@@ -151,7 +151,7 @@ abstract class Wrapper
 
             return $this;
         } catch (\Error $e) {
-            throw new \BadMethodCallException('Method ' . static::class . '::' . $name . '() does not exists');
+            throw new \BadMethodCallException('Method '.static::class.'::'.$name.'() does not exists');
         }
     }
 

--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -88,7 +88,7 @@ abstract class Wrapper
      *
      * @return Browsershot
      */
-    protected function browsershot(): Browsershot
+    public function browsershot(): Browsershot
     {
         return $this->browsershot;
     }


### PR DESCRIPTION
I ran into the situation where I need the retrieved HTML as well for a Screenshot request.

When I have something like the following example I can't get the bodyHtml value of browsershot:
```php
$request = Screenshot::loadUrl($url);
$request->windowSize(1920, 1080)
                ->storeAs('public/screenshots', $filename);

$html = $request->bodyHtml();
```

This is because `$this` is returned for forwarded calls which is fine for the most cases: https://github.com/verumconsilium/laravel-browsershot/blob/master/src/Wrapper.php#L150

For more flexibility I've made the getter `browsershot()` public to be able to retrieve the html like this:

```php
$request = Screenshot::loadUrl($url);
$request->windowSize(1920, 1080)
                ->storeAs('public/screenshots', $filename);

$html = $request->browsershot()->bodyHtml();
```

More calls where the return value of the function called on browsershot is needed are now possible as well.